### PR TITLE
NDCUM-330 - Launchpad

### DIFF
--- a/bamboo/build/create-artifacts.sh
+++ b/bamboo/build/create-artifacts.sh
@@ -60,6 +60,6 @@ for stage in development SIT UAT PROD; do
         --rm \
         --volume $(pwd)/artifacts:/artifacts \
         cumulus-dashboard:nsidc \
-        bash -c "set -x; KIBANAROOT=${KIBANAROOT} ESROOT=${ESROOT} ES_USER=${ES_USER} ES_PASSWORD=${ES_PASSWORD} APIROOT=${APIROOT} STAGE=${stage} SERVED_BY_CUMULUS_API=${cumulus_api} DAAC_NAME=${DAAC_NAME} HIDE_PDR=${HIDE_PDR} LABELS=${LABELS} npm run build;\
+        bash -c "set -x; KIBANAROOT=${KIBANAROOT} ESROOT=${ESROOT} ES_USER=${ES_USER} ES_PASSWORD=${ES_PASSWORD} APIROOT=${APIROOT} STAGE=${stage} SERVED_BY_CUMULUS_API=${cumulus_api} DAAC_NAME=${DAAC_NAME} HIDE_PDR=${HIDE_PDR} LABELS=${LABELS} AUTH_METHOD=${launchpad} npm run build;\
                  tar -cvzf /artifacts/cumulus-dashboard-dist-${stage}.tar.gz dist"
 done

--- a/bamboo/build/create-artifacts.sh
+++ b/bamboo/build/create-artifacts.sh
@@ -52,14 +52,16 @@ for stage in development SIT UAT PROD; do
 
     if [ ${stage} = "development" ]; then
         cumulus_api=true
+        AUTH_METHOD=earthdata
     else
         cumulus_api=${SERVED_BY_CUMULUS_API}
+        AUTH_METHOD=launchpad
     fi
 
     docker run \
         --rm \
         --volume $(pwd)/artifacts:/artifacts \
         cumulus-dashboard:nsidc \
-        bash -c "set -x; KIBANAROOT=${KIBANAROOT} ESROOT=${ESROOT} ES_USER=${ES_USER} ES_PASSWORD=${ES_PASSWORD} APIROOT=${APIROOT} STAGE=${stage} SERVED_BY_CUMULUS_API=${cumulus_api} DAAC_NAME=${DAAC_NAME} HIDE_PDR=${HIDE_PDR} LABELS=${LABELS} AUTH_METHOD='launchpad' npm run build;\
+        bash -c "set -x; KIBANAROOT=${KIBANAROOT} ESROOT=${ESROOT} ES_USER=${ES_USER} ES_PASSWORD=${ES_PASSWORD} APIROOT=${APIROOT} STAGE=${stage} SERVED_BY_CUMULUS_API=${cumulus_api} DAAC_NAME=${DAAC_NAME} HIDE_PDR=${HIDE_PDR} LABELS=${LABELS} AUTH_METHOD=${AUTH_METHOD} npm run build;\
                  tar -cvzf /artifacts/cumulus-dashboard-dist-${stage}.tar.gz dist"
 done

--- a/bamboo/build/create-artifacts.sh
+++ b/bamboo/build/create-artifacts.sh
@@ -60,6 +60,6 @@ for stage in development SIT UAT PROD; do
         --rm \
         --volume $(pwd)/artifacts:/artifacts \
         cumulus-dashboard:nsidc \
-        bash -c "set -x; KIBANAROOT=${KIBANAROOT} ESROOT=${ESROOT} ES_USER=${ES_USER} ES_PASSWORD=${ES_PASSWORD} APIROOT=${APIROOT} STAGE=${stage} SERVED_BY_CUMULUS_API=${cumulus_api} DAAC_NAME=${DAAC_NAME} HIDE_PDR=${HIDE_PDR} LABELS=${LABELS} AUTH_METHOD=${launchpad} npm run build;\
+        bash -c "set -x; KIBANAROOT=${KIBANAROOT} ESROOT=${ESROOT} ES_USER=${ES_USER} ES_PASSWORD=${ES_PASSWORD} APIROOT=${APIROOT} STAGE=${stage} SERVED_BY_CUMULUS_API=${cumulus_api} DAAC_NAME=${DAAC_NAME} HIDE_PDR=${HIDE_PDR} LABELS=${LABELS} AUTH_METHOD='launchpad' npm run build;\
                  tar -cvzf /artifacts/cumulus-dashboard-dist-${stage}.tar.gz dist"
 done


### PR DESCRIPTION
* use `AUTH_METHOD=earthdata` in SBX, use `launchpad` for all other envs

See also https://github.com/nsidc/CIRRUS-NSIDC/pull/61